### PR TITLE
Fix how modifications work in multi-module environments (aka fix guardian shield multiple spawn)

### DIFF
--- a/src/exoticatechnologies/hullmods/ExoticaTechHM.java
+++ b/src/exoticatechnologies/hullmods/ExoticaTechHM.java
@@ -103,15 +103,18 @@ public class ExoticaTechHM extends BaseHullMod {
 
         for (Exotic exotic : ExoticsHandler.INSTANCE.getEXOTIC_LIST()) {
             if (!mods.hasExotic(exotic)) continue;
-
-            if (cachedCheckIsModule(ship) && !exotic.shouldAffectModule(ship.getParentStation(), ship)) continue;
+            boolean exoticAppliesToModules = exotic.shouldAffectModule(ship.getParentStation(), ship);
+            boolean exoticSharesEffectWithAllModules = exotic.shouldShareEffectToOtherModules(ship.getParentStation(), ship);
+            if (cachedCheckIsModule(ship) && !exoticAppliesToModules && !exoticSharesEffectWithAllModules) continue;
 
             exotic.advanceInCombatUnpaused(ship, amount, member, mods, Objects.requireNonNull(mods.getExoticData(exotic)));
         }
 
         for (Upgrade upgrade : UpgradesHandler.UPGRADES_LIST) {
             if (!mods.hasUpgrade(upgrade)) continue;
-            if (cachedCheckIsModule(ship) && !upgrade.shouldAffectModule(ship.getParentStation(), ship)) continue;
+            boolean upgradeAppliesToModules = upgrade.shouldAffectModule(ship.getParentStation(), ship);
+            boolean upgradeSharesEffectWithAllModules = upgrade.shouldShareEffectToOtherModules(ship.getParentStation(), ship);
+            if (cachedCheckIsModule(ship) && !upgradeAppliesToModules && !upgradeSharesEffectWithAllModules) continue;
 
             upgrade.advanceInCombatUnpaused(ship, amount, member, mods);
         }
@@ -145,6 +148,11 @@ public class ExoticaTechHM extends BaseHullMod {
             return;
         }
 
+        // Unlike the other two places where we checked whether the modification should share it's effects across other
+        // modules, we don't need to do this here. The other two places decide whether the modification got installed
+        // and had it's applyToShip() method called on every module, and now that everything no longer gets installed
+        // everywhere, we don't need to check that here; this only calls applyToStats
+
         for (Exotic exotic : ExoticsHandler.INSTANCE.getEXOTIC_LIST()) {
             if (!mods.hasExotic(exotic)) continue;
             if (stats.getFleetMember() != null && stats.getFleetMember().getShipName() == null && !exotic.shouldAffectModule(stats)) continue;
@@ -170,13 +178,17 @@ public class ExoticaTechHM extends BaseHullMod {
 
         for (Exotic exotic : ExoticsHandler.INSTANCE.getEXOTIC_LIST()) {
             if (!mods.hasExotic(exotic)) continue;
-            if (cachedCheckIsModule(ship) && !exotic.shouldAffectModule(ship.getParentStation(), ship)) continue;
+            boolean exoticAppliesToModules = exotic.shouldAffectModule(ship.getParentStation(), ship);
+            boolean exoticSharesEffectWithAllModules = exotic.shouldShareEffectToOtherModules(ship.getParentStation(), ship);
+            if (cachedCheckIsModule(ship) && !exoticAppliesToModules && !exoticSharesEffectWithAllModules) continue;
             exotic.applyToShip(id, member, ship, mods, Objects.requireNonNull(mods.getExoticData(exotic)));
         }
 
         for (Upgrade upgrade : UpgradesHandler.UPGRADES_LIST) {
             if (!mods.hasUpgrade(upgrade)) continue;
-            if (cachedCheckIsModule(ship) && !upgrade.shouldAffectModule(ship.getParentStation(), ship)) continue;
+            boolean upgradeAppliesToModules = upgrade.shouldAffectModule(ship.getParentStation(), ship);
+            boolean upgradeSharesEffectWithAllModules = upgrade.shouldShareEffectToOtherModules(ship.getParentStation(), ship);
+            if (cachedCheckIsModule(ship) && !upgradeAppliesToModules && !upgradeSharesEffectWithAllModules) continue;
             upgrade.applyToShip(member, ship, mods);
         }
     }

--- a/src/exoticatechnologies/modifications/Modification.kt
+++ b/src/exoticatechnologies/modifications/Modification.kt
@@ -7,9 +7,12 @@ import com.fs.starfarer.api.combat.MutableShipStatsAPI
 import com.fs.starfarer.api.combat.ShipAPI
 import com.fs.starfarer.api.combat.ShipVariantAPI
 import com.fs.starfarer.api.fleet.FleetMemberAPI
+import exoticatechnologies.hullmods.ExoticaTechHM
 import exoticatechnologies.modifications.conditions.Condition
 import exoticatechnologies.modifications.conditions.ConditionDict
 import exoticatechnologies.modifications.conditions.toList
+import exoticatechnologies.modifications.exotics.Exotic
+import exoticatechnologies.modifications.upgrades.Upgrade
 import org.apache.log4j.Logger
 import org.jetbrains.annotations.Nullable
 import org.json.JSONObject
@@ -122,7 +125,17 @@ abstract class Modification(val key: String, val settings: JSONObject) {
      * Whether the modification is installable in non-main modules for multi-module ships,
      * and whether it should apply it's effects to all other modules.
      *
-     * This version is called in [BaseHullMod.applyEffectsBeforeShipCreation]
+     * This version is called in [ExoticaTechHM]'s [BaseHullMod.applyEffectsBeforeShipCreation]
+     *
+     * This call determines whether the following methods will be called on modules:
+     * - [Exotic.advanceInCombatUnpaused]
+     * - [Exotic.applyExoticToStats]
+     * - [Exotic.applyToShip]
+     * - [Exotic.applyToFighters]
+     * - [Upgrade.advanceInCombatUnpaused]
+     * - [Upgrade.applyUpgradeToStats]
+     * - [Upgrade.applyToShip]
+     * - [Upgrade.applyToFighters]
      *
      * **NOTE** A certain false-positive can be observed when playing in 'simulation' mode vs actual combat;
      * namely, while a mod installed on a module (in a multi-module environment) will affect only the module it's
@@ -140,7 +153,9 @@ abstract class Modification(val key: String, val settings: JSONObject) {
      * Whether the modification is installable in non-main modules for multi-module ships,
      * and whether it should apply it's effects to all other modules.
      *
-     * This version is called in [BaseHullMod.applyEffectsAfterShipCreation]
+     * This version is called in [ExoticaTechHM]'s [BaseHullMod.applyEffectsAfterShipCreation],
+     * and is used mainly to determine whether [Exotic.applyExoticToStats] and [Upgrade.applyUpgradeToStats]
+     * are called on modules
      *
      * **NOTE** A certain false-positive can be observed when playing in 'simulation' mode vs actual combat;
      * namely, while a mod installed on a module (in a multi-module environment) will affect only the module it's

--- a/src/exoticatechnologies/modifications/exotics/Exotic.kt
+++ b/src/exoticatechnologies/modifications/exotics/Exotic.kt
@@ -24,6 +24,10 @@ import org.json.JSONObject
  *
  * Remember to override [color] to change the item's name in the description title.
  *
+ *
+ * **NOTE:** By default, Exotics apply their effects to just the module to which they have been installed
+ * unless [shouldShareEffectToOtherModules] is overriden to return **true**
+ *
  * @see getBasePrice
  */
 abstract class Exotic(key: String, settings: JSONObject) : Modification(key, settings) {

--- a/src/exoticatechnologies/modifications/exotics/impl/GuardianShield.kt
+++ b/src/exoticatechnologies/modifications/exotics/impl/GuardianShield.kt
@@ -826,7 +826,7 @@ class GuardianShield(key: String, settings: JSONObject) : Exotic(key, settings) 
         }
 
         private const val LOGTAG = "GuardianShield"
-        private const val LOGS_ENABLED = true
+        private const val LOGS_ENABLED = false
         private const val LOG_FLUX = false
     }
 }

--- a/src/exoticatechnologies/modifications/upgrades/Upgrade.kt
+++ b/src/exoticatechnologies/modifications/upgrades/Upgrade.kt
@@ -26,6 +26,9 @@ import kotlin.math.roundToInt
  * Abstract base class for all Upgrade systems in the ExoticaTech mod.
  *
  * Remember to override [color] to change the item's name in the description title.
+ *
+ * **NOTE:** By default, Upgrades apply their effects to just the module to which they have been installed
+ * unless [shouldShareEffectToOtherModules] is overriden to return **true**
  */
 open class Upgrade(key: String, settings: JSONObject) : Modification(key, settings) {
     val resourceRatios: MutableMap<String, Float> = LinkedHashMap()


### PR DESCRIPTION
While this PR set out to do one simple thing - fix how GuardianShield behaves on just one ship - the ED Shipyard Wurgandal - the problem turned out to be actually way deeper than that; not only do multi-module ships spawned GuardianShields on *all* of their modules, but controlling that turned out to be hard as well. Or rather - impossible.

The initial attempts tried preventing some race-conditions and whatnot by introducing synchronization mechanisms to GuardianShield and the drone spawning methods, but after some exploratory legwork it became clear that it wasn't due to the GuardianShield installed on the main module; it was from different guardian shields installed on other modules.

So, after digging deeper it became apparent that `shouldAffectModule()` method was in charge of both whether the modification is installable on modules **and** whether it's shared across all other modules. So what had to be fixed became clear, and with the newest framework extension - `Modification::shouldShareEffectToOtherModules()` which is now in control of everything the `ExoticaTechHM` hullmod does with modifications (exoticas and upgrades) on the ships/modules until an even finer-grained control becomes necessary.

However, this somewhat throws a wrench in the stuff planned to-be done in #25 as well as issue #16 as well as opening a whole new can of worms - now that this change is in place, all Exoticas and Upgrades will work only on the module where they are installed; which was not their initial behavior. This was further masked by me doing most of the testing in 'simulation' which unfortunately behaves quite differently from real combat, whereas in simulation exoticas worked for just the modules they were present on, whereas in real combat exoticas (apparently) worked on all modules of (multi-module) ships they were installed on.

So now, this PR also set out to go through all Exoticas/Upgrades and further diversify them by giving them the ability to affect all modules on a case-by-case basis; initial idea is "modifications with penalties can affect whole ship, modifications without penalties will affect only the module they were installed on" to make overpowering your ship harder. We'll see how far we'll end up straying from this idea.