### PR TITLE
Fix edge-case in DestroyMethod

### DIFF
--- a/src/exoticatechnologies/ui/impl/shop/exotics/methods/DestroyMethod.kt
+++ b/src/exoticatechnologies/ui/impl/shop/exotics/methods/DestroyMethod.kt
@@ -40,7 +40,8 @@ open class DestroyMethod : ExoticMethod {
             }
 
             if (extraBandwidth > 0) {
-                return (shipBandwidth - mods.getUsedBandwidth()) > extraBandwidth
+                val shipBandwidthVsModsUsedBandwidthDifference = shipBandwidth - mods.getUsedBandwidth()
+                return shipBandwidthVsModsUsedBandwidthDifference >= extraBandwidth
             }
             return true
         }


### PR DESCRIPTION
For some reason, when exotics were giving out extra bandwidth, it was required that (shipBandwidth - usedBandwidth) be greated than extra bandwidth.

Which utterly fails for a base case of:
Exotic gives out 50 extra bandwidth
Ship uses 0 bandwidth
ugh, i forgot the exact numbers but it was failing because 50 was not greater than 50 ...

In any case, this is being done because for some reason - installed alpha subcore on a ship without any other upgrades/mods wasn't able to remove it.

Ahh, i see now - somehow the ship rolled 0 bandwidth. So if a ship has 0 bandwidth, and all of it's bandwidth is the extra bandwidth it received from AlphaSubcore, then it couldn't remove it because the requirement was for ShipBandwidthWithExtra to be greater than extra, instead of greater-or-equal.

This fixes it.