### PR TITLE
Fix the real problem with HullmodExotics that was broken in #26 - installing on correct mods, and a few more bugfixes

### DIFF
--- a/src/exoticatechnologies/modifications/ShipModLoader.kt
+++ b/src/exoticatechnologies/modifications/ShipModLoader.kt
@@ -64,6 +64,11 @@ class ShipModLoader {
 
             return null
         }
+
+        @JvmStatic
+        fun getFromVariant(variant: ShipVariantAPI): ShipModifications? {
+            return VariantTagProvider.inst.getFromVariant(variant)
+        }
     }
 
     interface Provider {

--- a/src/exoticatechnologies/modifications/VariantTagProvider.kt
+++ b/src/exoticatechnologies/modifications/VariantTagProvider.kt
@@ -30,7 +30,7 @@ open class VariantTagProvider : ShipModLoader.Provider {
         }
 
         val cacheMods: ShipModifications? = cache.keys
-            .filter { it == member }
+            .filter { it == member && it.specId == member.specId }
             .firstNotNullOfOrNull { cache[it] }
 
         if (cacheMods != null) {
@@ -81,7 +81,8 @@ open class VariantTagProvider : ShipModLoader.Provider {
 
         if (exoticaTag != null) {
             val jsonStr = exoticaTag.replace(EXOTICA_INDICATOR, "")
-            return convertFromJson(jsonStr)
+            val mods = convertFromJson(jsonStr)
+            return mods
         }
 
         return null

--- a/src/exoticatechnologies/modifications/exotics/impl/HullmodExotic.kt
+++ b/src/exoticatechnologies/modifications/exotics/impl/HullmodExotic.kt
@@ -206,20 +206,31 @@ open class HullmodExotic(
      */
     private fun unapplyExoticHullmodAndRemoveExoticaAndHullmod(member: FleetMemberAPI, moduleVariant: ShipVariantAPI, optionalMemberMods: Optional<ShipModifications>) {
         // If optional is there
-        if (optionalMemberMods.isPresent()) {
+        val hasAnyMods = if (optionalMemberMods.isPresent()) {
             val memberMods = optionalMemberMods.get()
             memberMods.removeExotic(this@HullmodExotic)
             ShipModLoader.set(member, moduleVariant, memberMods)
+
+            // And return if we have any mods (exotics or upgrades) left
+            memberMods.hasAnyModifications()
         } else {
             // Otherwise, extract them manually and use them
             val memberMods = get(member, moduleVariant)
             memberMods?.let { nonNullMods ->
                 nonNullMods.removeExotic(this@HullmodExotic)
-                ShipModLoader.set(member, moduleVariant, memberMods)
-            }
+                ShipModLoader.set(member, moduleVariant, nonNullMods)
+
+                // And return if we have any modifications (exotics or upgrades) left
+                nonNullMods.hasAnyModifications()
+            } ?: false
+            // In case we didn't have any non-null mods, let's default to 'false' for having more exotics
         }
         // And the shared common part for both that has nothing to do with the mods
-        ExoticaTechHM.addToFleetMember(member, moduleVariant)
+        // Remove "exoticatech" hullmod only if we ran out of exoticas on the member
+        if (hasAnyMods.not()) {
+            // If we don't have any more exotics, remove the "exoticatech" hullmod
+            ExoticaTechHM.addToFleetMember(member, moduleVariant)
+        }
         removeHullmodFromVariant(moduleVariant)
         // grab stats to use
         val stats = HullmodExoticHandler.getNonNullStatsToUse(member, moduleVariant)
@@ -302,15 +313,24 @@ open class HullmodExotic(
      * - and finally adds the ExoticaTech hullmod by calling [ExoticaTechHM.addToFleetMember]
      */
     private fun installThisHullmodExoticToFleetMembersVariant(member: FleetMemberAPI, moduleVariant: ShipVariantAPI, moduleVariantMods: ShipModifications) {
+        val hasAnyMods = moduleVariantMods.hasAnyModifications()
+
         installHullmodOnVariant(moduleVariant)
 
         // This is the installWorkaround code
-        //TODO check if we have it first before adding
-        moduleVariantMods.putExotic(ExoticData(this@HullmodExotic.key))
+        if (moduleVariantMods.isUnderExoticLimit(member)) {
+            if (moduleVariantMods.hasExotic(this@HullmodExotic.key).not()) {
+                moduleVariantMods.putExotic(ExoticData(this@HullmodExotic.key))
 
-        ShipModLoader.set(member, moduleVariant, moduleVariantMods)
-        // Install the exoticatech hullmod to show the thing we just installed
-        ExoticaTechHM.addToFleetMember(member, moduleVariant)
+                ShipModLoader.set(member, moduleVariant, moduleVariantMods)
+            }
+        } else {
+            logIfOverMinLogLevel("Bailing out - not installing HullmodExotic ${this} on module variant ${moduleVariant} due to already being at Max Exoticas Limit !!!", Level.ERROR)
+        }
+        // Install the exoticatech hullmod to show the thing we just installed - but only if we don't have mods alerady
+        if (hasAnyMods.not()) {
+            ExoticaTechHM.addToFleetMember(member, moduleVariant)
+        }
     }
 
     private fun logIfOverMinLogLevel(logMsg: String, logLevel: Level) {

--- a/src/exoticatechnologies/modifications/exotics/impl/HullmodExotic.kt
+++ b/src/exoticatechnologies/modifications/exotics/impl/HullmodExotic.kt
@@ -214,7 +214,6 @@ open class HullmodExotic(
             memberMods.hasAnyModifications()
         } else {
             // Otherwise, extract them manually and use them
-//            val memberMods = ShipModLoader.get(member, moduleVariant)   //TODO fix
             val memberMods = ShipModLoader.getFromVariant(moduleVariant)
             memberMods?.let { nonNullMods ->
                 nonNullMods.removeExotic(this@HullmodExotic)

--- a/src/exoticatechnologies/modifications/exotics/impl/HullmodExotic.kt
+++ b/src/exoticatechnologies/modifications/exotics/impl/HullmodExotic.kt
@@ -320,6 +320,8 @@ open class HullmodExotic(
             // Install the hullmod since we're under the exotic limit, this could have been done outside
             // but somehow feels cleaner to do here
             installHullmodOnVariant(moduleVariant)
+
+            // And proceed to install the HullmodExotic if we don't have it in our variant's ShipModifications
             if (moduleVariantMods.hasExotic(this@HullmodExotic.key).not()) {
                 // Install the HullmodExotic into the ShipModifications moduleVariant's "mods"
                 moduleVariantMods.putExotic(ExoticData(this@HullmodExotic.key))

--- a/src/exoticatechnologies/util/Extensions.kt
+++ b/src/exoticatechnologies/util/Extensions.kt
@@ -673,7 +673,7 @@ fun List<String>.containsIgnoreCase(string: String?): Boolean {
 fun getChildModuleVariantList(fleetMemberAPI: FleetMemberAPI): List<ShipVariantAPI> {
     val retVal = mutableListOf<ShipVariantAPI>()
     if (fleetMemberAPI.variant.moduleSlots == null || fleetMemberAPI.variant.moduleSlots.isEmpty()) return emptyList()
-    var moduleSlotList = fleetMemberAPI.variant.moduleSlots.asSortedStringList()
+    val moduleSlotList = fleetMemberAPI.variant.moduleSlots.asSortedStringList()
     for (slot in moduleSlotList) {
         val moduleVariant = fleetMemberAPI.variant.getModuleVariant(slot)
         retVal.add(moduleVariant)

--- a/src/exoticatechnologies/util/Extensions.kt
+++ b/src/exoticatechnologies/util/Extensions.kt
@@ -662,7 +662,7 @@ fun List<String>.containsIgnoreCase(string: String?): Boolean {
 }
 
 /**
- * Method that returns a list of all child module variants belonging to the passed-in [fleetMemberAPI]
+ * Method that returns a sorted list of all child module variants belonging to the passed-in [fleetMemberAPI]
  *
  * **NOTE:** Does **not** include the root module's variant in the list.
  *
@@ -673,12 +673,21 @@ fun List<String>.containsIgnoreCase(string: String?): Boolean {
 fun getChildModuleVariantList(fleetMemberAPI: FleetMemberAPI): List<ShipVariantAPI> {
     val retVal = mutableListOf<ShipVariantAPI>()
     if (fleetMemberAPI.variant.moduleSlots == null || fleetMemberAPI.variant.moduleSlots.isEmpty()) return emptyList()
-    val moduleSlotList = fleetMemberAPI.variant.moduleSlots
+    var moduleSlotList = fleetMemberAPI.variant.moduleSlots.asSortedStringList()
     for (slot in moduleSlotList) {
         val moduleVariant = fleetMemberAPI.variant.getModuleVariant(slot)
         retVal.add(moduleVariant)
     }
     return retVal.toList()
+}
+
+/**
+ * Returns a sorted list of List<String>
+ */
+fun List<String>.asSortedStringList(): List<String> {
+    val temp = this.toMutableList()
+    temp.sort()
+    return temp.toList()
 }
 
 /**


### PR DESCRIPTION
Besides reverting the revert of commit that brought the biggest "value" (yet unfortunately also broke HullmodExotics) - eab0661 which brought conditional ExoticaTech hullmod adding/removing as well as HullmodExotic installation (to avoid wiping the module once removed)  and 726246a which introduced "limiting" to at most "exotica limit" on each module, this PR also figured out a decent workaround to resolve all the outlying problems with hullmod exotics:
- Installing AlphaSubcore on main module while some children modules are "full" of exotics should **not** install on full modules
- removing AlphaSubcore from main module while children have/don't have it installed should neither wipe them clean or mix up their exotics/upgrades
- i forgot the third issue but it's also been taken care of before.
- Installing/removing from "Exotica Technologies" colony screen works super-reliable, installing/removing from refit is flaky.

All in all, this PR finishes what I started out last august.