### PR TITLE
Add a warning when trying to install HullmodExotics from Refit screen

### DIFF
--- a/data/strings/strings.json
+++ b/data/strings/strings.json
@@ -128,7 +128,8 @@
 		"InstallExoticChip": "Use chip",
 		"RecoverExotic": "Recover chip",
 		"DestroyExotic": "Destroy",
-		"InstalledTitle": "INSTALLED"
+		"InstalledTitle": "INSTALLED",
+		"DontDoFromRefitScreen": "Don't use from Refit screen."
 	},
 	"ExoticCosts": {
 		"BandwidthGivenByExotic": "Max bandwidth: *${bandwidth}* (*${exoticBandwidth}*)"

--- a/src/exoticatechnologies/modifications/Modification.kt
+++ b/src/exoticatechnologies/modifications/Modification.kt
@@ -238,6 +238,15 @@ abstract class Modification(val key: String, val settings: JSONObject) {
      */
     open fun shouldAffectModulesToShareEffectsToOtherModules() = true
 
+    /**
+     * Due to observed problems with some modifications when they're applied from the Refit screen versus the
+     * Exotica Technologies colony screen, this method is used to signify whether they should show the warning
+     * above the apply button, to make it clear that they **should** instead be installed/uninstalled from Exotica screen
+     *
+     * Defaults to **[false]**
+     */
+    open fun showWarningIfApplyingFromRefitScreen() = false
+
     open fun canApply(member: FleetMemberAPI, mods: ShipModifications?): Boolean {
         return canApply(member, member.variant, mods)
     }

--- a/src/exoticatechnologies/modifications/ShipModLoader.kt
+++ b/src/exoticatechnologies/modifications/ShipModLoader.kt
@@ -32,21 +32,25 @@ class ShipModLoader {
         private val inst = ShipModLoader()
 
         @JvmStatic
+        @Synchronized
         fun get(member: FleetMemberAPI, variant: ShipVariantAPI): ShipModifications? {
             return inst.getData(member, variant)
         }
 
         @JvmStatic
+        @Synchronized
         fun set(member: FleetMemberAPI, variant: ShipVariantAPI, mods: ShipModifications) {
             return inst.saveData(member, variant, mods)
         }
 
         @JvmStatic
+        @Synchronized
         fun remove(member: FleetMemberAPI, variant: ShipVariantAPI) {
             return inst.removeData(member, variant)
         }
 
         @JvmStatic
+        @Synchronized
         fun getForSpecialData(shipData: ShipRecoverySpecial.PerShipData): ShipModifications? {
             if (shipData.getVariant() != null) {
                 val mods = VariantTagProvider.inst.getFromVariant(shipData.getVariant())
@@ -66,6 +70,7 @@ class ShipModLoader {
         }
 
         @JvmStatic
+        @Synchronized
         fun getFromVariant(variant: ShipVariantAPI): ShipModifications? {
             return VariantTagProvider.inst.getFromVariant(variant)
         }

--- a/src/exoticatechnologies/modifications/ShipModifications.kt
+++ b/src/exoticatechnologies/modifications/ShipModifications.kt
@@ -161,8 +161,8 @@ class ShipModifications(var bandwidth: Float, var upgrades: ETUpgrades, var exot
      *
      * @return whether the [Exotic] was successfully removed or not
      */
-    fun removeExotic(exotic: Exotic) {
-        exotics.removeExotic(exotic)
+    fun removeExotic(exotic: Exotic): Boolean {
+        return exotics.removeExotic(exotic)
     }
 
     fun getExoticData(exotic: Exotic): ExoticData? {

--- a/src/exoticatechnologies/modifications/exotics/impl/HullmodExotic.kt
+++ b/src/exoticatechnologies/modifications/exotics/impl/HullmodExotic.kt
@@ -207,7 +207,7 @@ open class HullmodExotic(
      */
     private fun unapplyExoticHullmodAndRemoveExoticaAndHullmod(member: FleetMemberAPI, moduleVariant: ShipVariantAPI, optionalMemberMods: Optional<ShipModifications>) {
         // If optional is there
-        val hasAnyMods = if (optionalMemberMods.isPresent()) {
+        if (optionalMemberMods.isPresent()) {
             val memberMods = optionalMemberMods.get()
             memberMods.removeExotic(this@HullmodExotic)
             ShipModLoader.set(member, moduleVariant, memberMods)
@@ -216,6 +216,7 @@ open class HullmodExotic(
             memberMods.hasAnyModifications()
         } else {
             // Otherwise, extract them manually and use them
+            val mods = ShipModLoader.get(member, moduleVariant)
             val memberMods = ShipModLoader.getFromVariant(moduleVariant)
             memberMods?.let { nonNullMods ->
                 nonNullMods.removeExotic(this@HullmodExotic)
@@ -223,15 +224,12 @@ open class HullmodExotic(
 
                 // And return if we have any modifications (exotics or upgrades) left
                 nonNullMods.hasAnyModifications()
-            } ?: false
+            }
             // In case we didn't have any non-null mods, let's default to 'false' for having more exotics
         }
-        // And the shared common part for both that has nothing to do with the mods
-        // Remove "exoticatech" hullmod only if we ran out of exoticas on the member
-        if (hasAnyMods.not()) {
-            // If we don't have any more exotics, remove the "exoticatech" hullmod
-            ExoticaTechHM.addToFleetMember(member, moduleVariant)
-        }
+        // Refresh (or remove) the ExoticaTech hullmod
+        ExoticaTechHM.addToFleetMember(member, moduleVariant)
+
         removeHullmodFromVariant(moduleVariant)
         // grab stats to use
         val stats = HullmodExoticHandler.getNonNullStatsToUse(member, moduleVariant)

--- a/src/exoticatechnologies/modifications/exotics/impl/HullmodExotic.kt
+++ b/src/exoticatechnologies/modifications/exotics/impl/HullmodExotic.kt
@@ -48,6 +48,8 @@ open class HullmodExotic(
             }
         }
 
+    override fun showWarningIfApplyingFromRefitScreen() = true
+
     override fun onInstall(member: FleetMemberAPI) {
         val shouldShareEffectToOtherModules = shouldShareEffectToOtherModules(null, null)
         val isChildModule = member.shipName.isNullOrEmpty()

--- a/src/exoticatechnologies/ui/impl/shop/exotics/ExoticMethodsUIPlugin.kt
+++ b/src/exoticatechnologies/ui/impl/shop/exotics/ExoticMethodsUIPlugin.kt
@@ -17,6 +17,8 @@ import exoticatechnologies.ui.InteractiveUIPanelPlugin
 import exoticatechnologies.ui.StringTooltip
 import exoticatechnologies.ui.impl.shop.exotics.methods.ExoticMethod
 import exoticatechnologies.util.StringUtils
+import exoticatechnologies.util.runningFromExoticaTechnologiesScreen
+import exoticatechnologies.util.runningFromRefitScreen
 import org.apache.log4j.Logger
 import java.awt.Color
 
@@ -64,6 +66,8 @@ class ExoticMethodsUIPlugin(
             showCannotApply(mods, tooltip)
 
             prev = tooltip.prev
+        } else if (exotic.showWarningIfApplyingFromRefitScreen() && runningFromExoticaTechnologiesScreen().not()) {
+            tooltip.addTitle(StringUtils.getString("ExoticsDialog", "DontDoFromRefitScreen"), Color(200, 50, 0))
         } else if (!isUnderExoticLimit(member, mods)) {
             tooltip.addTitle(StringUtils.getString("Conditions", "CannotApplyTitle"), Color(200, 100, 100))
 

--- a/src/exoticatechnologies/util/Extensions.kt
+++ b/src/exoticatechnologies/util/Extensions.kt
@@ -694,8 +694,14 @@ fun List<String>.asSortedStringList(): List<String> {
  * Method that checks whether we're currently located in the Refit screen or not.
  */
 fun runningFromRefitScreen(): Boolean {
-    val runningFromRefitScreen = Global.getSector().campaignUI.currentCoreTab == CoreUITabId.REFIT
-    return runningFromRefitScreen
+    return StarsectorAPIInteractor.runningFromRefitScreen()
+}
+
+/**
+ * Method that checks whether we're currently located in the "Exotica Technologies" screen or not.
+ */
+fun runningFromExoticaTechnologiesScreen(): Boolean {
+    return StarsectorAPIInteractor.runningFromExoticaTechnologiesScreen()
 }
 
 val <T> T.exhaustive: T

--- a/src/exoticatechnologies/util/StarsectorAPIInteractor.kt
+++ b/src/exoticatechnologies/util/StarsectorAPIInteractor.kt
@@ -17,6 +17,15 @@ object StarsectorAPIInteractor {
     private var TEST_MODE_VALUE = false
 
     /**
+     * Check whether we're running from "Exotica Technologies" screen
+     */
+    fun runningFromExoticaTechnologiesScreen(): Boolean {
+        // This one will just naively rely on the fact that we have options showing in the background
+        val hasOptions = Global.getSector().campaignUI.currentInteractionDialog.optionPanel.hasOptions()
+        return hasOptions
+    }
+
+    /**
      * Returns whether we're currently located in the Refit screen or not
      */
     fun runningFromRefitScreen(): Boolean {
@@ -28,13 +37,15 @@ object StarsectorAPIInteractor {
     }
 
     private fun actualStarsectorAPIrunningFromRefitScreen(): Boolean {
+        // Refit screen is going to be on the REFIT core UI tab and won't have options
+        val hasOptions = Global.getSector().campaignUI.currentInteractionDialog.optionPanel.hasOptions()
         val runningFromRefitScreen = Global.getSector().campaignUI.currentCoreTab == CoreUITabId.REFIT
-        return runningFromRefitScreen
+        return runningFromRefitScreen && hasOptions.not()
     }
 
     /**
      * Method to set whether we're currently running in test mode, and additionally set the return value.
-     * 
+     *
      * Obviously, super necessary since while we're running tests, all StarsectorAPI calls will simply return null.
      *
      * **NEVER USE THIS IN PRODUCTION CODE**


### PR DESCRIPTION
Things were extended a bit, and the warning shows up good however, due to making the checks whether we're running from ExoticaTech screen or Refit screen a bit stricter, it breaks a certain usecase:

- install NanotechArmor on one child module
- install EqualizerCore on another child module
- install AlphaSubcore from exoticatech screen
- remove AlphaSubcore from exoticatech screen

The AlphaSubcore will not be removed from the child modules.

Need to check whether this actually works fine on the base branch, which probably *never* uses strict work mode to begin with, since CoreUI tabs are remembered even when they're not showing.

So the (old) typical:
- enter Refit
- press Escape
- enter exotica tech screen

surely still counts as being in "refit".

UPDATE:
Besides tightening the "runningFromRefit()" and "runningFromExoticaScreen()" methods, this PR also adds synchronization to ShipModLoader.

The "problematic" usecase steps identified above no longer repro, and the warning on the AlphaSubcore shows when using from Refit screen.