### PR TITLE
Block removing from refit

### DIFF
--- a/src/exoticatechnologies/modifications/Modification.kt
+++ b/src/exoticatechnologies/modifications/Modification.kt
@@ -13,6 +13,8 @@ import exoticatechnologies.modifications.conditions.ConditionDict
 import exoticatechnologies.modifications.conditions.toList
 import exoticatechnologies.modifications.exotics.Exotic
 import exoticatechnologies.modifications.upgrades.Upgrade
+import exoticatechnologies.ui.impl.shop.exotics.ExoticMethodsUIPlugin
+import exoticatechnologies.ui.impl.shop.exotics.methods.ExoticMethod
 import org.apache.log4j.Logger
 import org.jetbrains.annotations.Nullable
 import org.json.JSONObject
@@ -243,9 +245,26 @@ abstract class Modification(val key: String, val settings: JSONObject) {
      * Exotica Technologies colony screen, this method is used to signify whether they should show the warning
      * above the apply button, to make it clear that they **should** instead be installed/uninstalled from Exotica screen
      *
+     * It will also block "removal" [ExoticMethod]s in [ExoticMethodsUIPlugin] if [blockRemovalFromRefitScreen] is set
+     *
+     *
      * Defaults to **[false]**
+     *
+     * @return whether this modification should show a warning in exotica screen
+     *
+     * @see blockRemovalFromRefitScreen
      */
     open fun showWarningIfApplyingFromRefitScreen() = false
+
+    /**
+     * Highly related to [showWarningIfApplyingFromRefitScreen] - this method is in charge of dictating whether removing
+     * the modification from the refit screen should be blocked or not
+     *
+     * @return whether removing should be blocked from Refit screen
+     *
+     * @see showWarningIfApplyingFromRefitScreen
+     */
+    open fun blockRemovalFromRefitScreen() = false
 
     open fun canApply(member: FleetMemberAPI, mods: ShipModifications?): Boolean {
         return canApply(member, member.variant, mods)

--- a/src/exoticatechnologies/modifications/exotics/impl/HullmodExotic.kt
+++ b/src/exoticatechnologies/modifications/exotics/impl/HullmodExotic.kt
@@ -49,6 +49,7 @@ open class HullmodExotic(
         }
 
     override fun showWarningIfApplyingFromRefitScreen() = true
+    override fun blockRemovalFromRefitScreen() = true
 
     override fun onInstall(member: FleetMemberAPI) {
         val shouldShareEffectToOtherModules = shouldShareEffectToOtherModules(null, null)

--- a/src/exoticatechnologies/ui/impl/shop/exotics/ExoticMethodsUIPlugin.kt
+++ b/src/exoticatechnologies/ui/impl/shop/exotics/ExoticMethodsUIPlugin.kt
@@ -20,7 +20,6 @@ import exoticatechnologies.ui.impl.shop.exotics.methods.ExoticMethod
 import exoticatechnologies.ui.impl.shop.exotics.methods.RecoverMethod
 import exoticatechnologies.util.StringUtils
 import exoticatechnologies.util.runningFromExoticaTechnologiesScreen
-import exoticatechnologies.util.runningFromRefitScreen
 import org.apache.log4j.Logger
 import java.awt.Color
 
@@ -52,8 +51,19 @@ class ExoticMethodsUIPlugin(
         methodsTooltip = tooltip
 
         var prev: UIComponentAPI? = null
+        val shouldExoticWarn = exotic.showWarningIfApplyingFromRefitScreen() && runningFromExoticaTechnologiesScreen().not()
         if (mods.hasExotic(exotic)) {
-            tooltip.addTitle(StringUtils.getString("ExoticsDialog", "InstalledTitle"))
+            // Due to the "warning" thing complicating things a bit, lets make it proper by joining the 'install' and 'warning'
+            if (shouldExoticWarn) {
+                // In case we need to warn, we need to do two things:
+                // concat the "installed" and "warning" string
+                // add them together in red color
+                val joinedInstallWarningString = "${StringUtils.getString("ExoticsDialog", "InstalledTitle")} - ${StringUtils.getString("ExoticsDialog", "DontDoFromRefitScreen")}"
+                tooltip.addTitle(joinedInstallWarningString, Color(200, 50, 0))
+            } else {
+                // Otherwise, we just did what we used to do - show normal 'installed' string
+                tooltip.addTitle(StringUtils.getString("ExoticsDialog", "InstalledTitle"))
+            }
         } else if (!exotic.canApply(member, mods)) {
             if (exotic.conditionsDisjunct) {
                 val titleString = StringUtils
@@ -68,7 +78,7 @@ class ExoticMethodsUIPlugin(
             showCannotApply(mods, tooltip)
 
             prev = tooltip.prev
-        } else if (exotic.showWarningIfApplyingFromRefitScreen() && runningFromExoticaTechnologiesScreen().not()) {
+        } else if (shouldExoticWarn) {
             tooltip.addTitle(StringUtils.getString("ExoticsDialog", "DontDoFromRefitScreen"), Color(200, 50, 0))
             // While it would make sense to set a 'flag' here to prevent removal, this one will be shown only *before*
             // an Exotic has been installed. After it's been installed, the first if() will add a "INSTALLED" tooltip


### PR DESCRIPTION
Extend the "warning" idea so that exotics can toggle whether they should block removal from Refit or not