### PR TITLE
Fix Industry Bandwidth Multipliers

### DIFF
--- a/src/exoticatechnologies/ETModSettings.java
+++ b/src/exoticatechnologies/ETModSettings.java
@@ -80,7 +80,7 @@ public class ETModSettings {
 
             MAX_EXOTICS  = MagicSettings.getInteger(ETModPlugin.MOD_ID, MAX_EXOTICS_KEY);
 
-            productionBandwidthMults = MagicSettings.getFloatMap("industryBandwidthGenerationMultipliers", INDUSTRY_PRODUCTION_BANDWIDTH_MULT);
+            productionBandwidthMults = MagicSettings.getFloatMap(ETModPlugin.MOD_ID, INDUSTRY_PRODUCTION_BANDWIDTH_MULT);
         } catch (JSONException | IOException ex) {
             throw new RuntimeException(ex);
         }


### PR DESCRIPTION
Slight change to how the bandwidth multipliers are being loaded from modSettings.json, this should fix the following problem(s).

TEST STEPS:
- current develop branch
- run game
- trigger `et_reload` console command
- check log

BEFORE FIX:
the `WARN  org.magiclib.util.MagicSettings  - unable to find industryBandwidthGenerationMultipliers in modSettings.json` error appears in the log.

AFTER FIX:
no error/warning appears in the log.


Resolves: 
```
WARN  org.magiclib.util.MagicSettings  - unable to find industryBandwidthGenerationMultipliers in modSettings.json
```

The alternative workaround without recompiling the modSettings.json would need a new entry to be like so:
```
	"industryBandwidthGenerationMultipliers": {
		"industryBandwidthGenerationMultipliers": {
			"heavyindustry": 1.0,
			"orbitalworks": 1.0,
			"IndEvo_Scrapyard": 0.75,
			"IndEvo_EngHub": 1.25,
			"ms_modularFac": 1.0,
			"ms_massIndustry": 1.0,
			"ms_militaryProduction": 1.0,
			"ms_orbitalShipyard": 1.0,
			"triheavy": 2.0,
			"hegeheavy": 2.0,
			"orbitalheavy": 1.5
		}
	}
```